### PR TITLE
🚑 Fixes calculation for average processing time

### DIFF
--- a/adguardhome/stats.py
+++ b/adguardhome/stats.py
@@ -45,7 +45,7 @@ class AdGuardHomeStats:
     async def avg_processing_time(self) -> float:
         """Return avarage processing time of DNS queries (in ms)."""
         response = await self._adguard._request("stats")
-        return round(response["avg_processing_time"] * 100, 2)
+        return round(response["avg_processing_time"] * 1000, 2)
 
     async def period(self) -> int:
         """Return the time period to keep data (in days)."""

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -153,13 +153,13 @@ async def test_avg_processing_time(aresponses):
         aresponses.Response(
             status=200,
             headers={"Content-Type": "application/json"},
-            text='{"avg_processing_time": 0.0314}',
+            text='{"avg_processing_time": 0.03141}',
         ),
     )
     async with aiohttp.ClientSession() as session:
         adguard = AdGuardHome("example.com", session=session)
         result = await adguard.stats.avg_processing_time()
-        assert result == 3.14
+        assert result == 31.41
 
 
 @pytest.mark.asyncio
@@ -215,10 +215,10 @@ async def test_content_type_workarond(aresponses):
         aresponses.Response(
             status=200,
             headers={"Content-Type": "text/plain; charset=utf-8"},
-            text='{"avg_processing_time": 0.0314}',
+            text='{"avg_processing_time": 0.03141}',
         ),
     )
     async with aiohttp.ClientSession() as session:
         adguard = AdGuardHome("example.com", session=session)
         result = await adguard.stats.avg_processing_time()
-        assert result == 3.14
+        assert result == 31.41


### PR DESCRIPTION
The AdGuard Home API returns the value in seconds. To correctly convert that value into milliseconds, the multiplication should be 1000.

**API result**
```json
{"avg_processing_time": "0.008353"}
```

I noticed this in Home Assistant. The AdGuard Home page showed my average processing time as 8ms, while the Home Assistant sensor (incorrectly) had 0.8ms for this value.

**AdGuard Home**
![image](https://user-images.githubusercontent.com/5155694/78284096-25647d00-751f-11ea-9777-1461a8e11f53.png)

**Home Assistant sensor**
![image](https://user-images.githubusercontent.com/5155694/78284124-31e8d580-751f-11ea-80c4-01732238a4dc.png)
