### PR TITLE
Added support for the DNS rewrite rules AdGuard API

### DIFF
--- a/src/adguardhome/__init__.py
+++ b/src/adguardhome/__init__.py
@@ -3,6 +3,7 @@
 from .adguardhome import AdGuardHome
 from .client import AutoClient, Client
 from .exceptions import AdGuardHomeConnectionError, AdGuardHomeError
+from .rewrite import RewriteRule
 
 __all__ = [
     "AdGuardHome",
@@ -10,4 +11,5 @@ __all__ = [
     "AdGuardHomeError",
     "AutoClient",
     "Client",
+    "RewriteRule",
 ]

--- a/src/adguardhome/adguardhome.py
+++ b/src/adguardhome/adguardhome.py
@@ -15,6 +15,7 @@ from .exceptions import AdGuardHomeConnectionError, AdGuardHomeError
 from .filtering import AdGuardHomeFiltering
 from .parental import AdGuardHomeParental
 from .querylog import AdGuardHomeQueryLog
+from .rewrite import AdGuardHomeRewrite
 from .safebrowsing import AdGuardHomeSafeBrowsing
 from .safesearch import AdGuardHomeSafeSearch
 from .stats import AdGuardHomeStats
@@ -79,6 +80,7 @@ class AdGuardHome:
         self.filtering = AdGuardHomeFiltering(self)
         self.parental = AdGuardHomeParental(self)
         self.querylog = AdGuardHomeQueryLog(self)
+        self.rewrite = AdGuardHomeRewrite(self)
         self.safebrowsing = AdGuardHomeSafeBrowsing(self)
         self.safesearch = AdGuardHomeSafeSearch(self)
         self.stats = AdGuardHomeStats(self)
@@ -92,7 +94,7 @@ class AdGuardHome:
         data: Any | None = None,
         json_data: dict[str, Any] | None = None,
         params: Mapping[str, str] | None = None,
-    ) -> dict[str, Any]:
+    ) -> Any:
         """Handle a request to the AdGuard Home instance.
 
         Make a request against the AdGuard Home API and handle the response.
@@ -109,7 +111,8 @@ class AdGuardHome:
         -------
             The response from the API. In case the response is a JSON response,
             the method will return a decoded JSON response as a Python
-            dictionary. In other cases, it will return the RAW text response.
+            dictionary or list. In other cases, it will return the RAW text
+            response.
 
         Raises:
         ------

--- a/src/adguardhome/rewrite.py
+++ b/src/adguardhome/rewrite.py
@@ -1,0 +1,85 @@
+"""Asynchronous Python client for the AdGuard Home API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .exceptions import AdGuardHomeError
+
+if TYPE_CHECKING:
+    from . import AdGuardHome
+
+
+@dataclass
+class RewriteRule:
+    """A DNS rewrite rule in AdGuard Home."""
+
+    domain: str
+    answer: str
+    enabled: bool = True
+
+
+@dataclass
+class AdGuardHomeRewrite:
+    """Controls AdGuard Home DNS rewrites."""
+
+    adguard: AdGuardHome
+
+    async def list_rules(self) -> list[RewriteRule]:
+        """Return all defined DNS rewrite rules.
+
+        Returns
+        -------
+            A list of DNS rewrite rules configured on the
+            AdGuard Home instance.
+
+        """
+        response = await self.adguard.request("rewrite/list")
+        return [RewriteRule(**entry) for entry in response or []]
+
+    async def add(self, domain: str, answer: str) -> None:
+        """Add a new DNS rewrite rule to AdGuard Home.
+
+        Args:
+        ----
+            domain: The domain pattern to rewrite (e.g., "*.example.com").
+            answer: The IP address or domain to rewrite to.
+
+        Raises:
+        ------
+            AdGuardHomeError: Failed adding the DNS rewrite rule.
+
+        """
+        try:
+            await self.adguard.request(
+                "rewrite/add",
+                method="POST",
+                json_data={"domain": domain, "answer": answer},
+            )
+        except AdGuardHomeError as exception:
+            msg = "Failed to add DNS rewrite rule to AdGuard Home"
+            raise AdGuardHomeError(msg) from exception
+
+    async def delete(self, domain: str, answer: str) -> None:
+        """Delete a DNS rewrite rule from AdGuard Home.
+
+        Args:
+        ----
+            domain: The domain pattern of the rewrite rule to delete.
+            answer: The IP address or domain of the rewrite rule to delete.
+
+        Raises:
+        ------
+            AdGuardHomeError: Failed to delete the DNS rewrite rule.
+
+        """
+        try:
+            await self.adguard.request(
+                "rewrite/delete",
+                method="POST",
+                json_data={"domain": domain, "answer": answer},
+            )
+        except AdGuardHomeError as exception:
+            msg = "Failed to delete DNS rewrite rule from AdGuard Home"
+            raise AdGuardHomeError(msg) from exception

--- a/tests/__snapshots__/test_rewrite.ambr
+++ b/tests/__snapshots__/test_rewrite.ambr
@@ -1,0 +1,7 @@
+# serializer version: 1
+# name: test_list_rules_snapshot
+  list([
+    RewriteRule(domain='*.example.com', answer='192.168.1.2', enabled=True),
+    RewriteRule(domain='ads.tracker.io', answer='127.0.0.1', enabled=False),
+  ])
+# ---

--- a/tests/fixtures/rewrite_list.json
+++ b/tests/fixtures/rewrite_list.json
@@ -1,0 +1,12 @@
+[
+  {
+    "domain": "*.example.com",
+    "answer": "192.168.1.2",
+    "enabled": true
+  },
+  {
+    "domain": "ads.tracker.io",
+    "answer": "127.0.0.1",
+    "enabled": false
+  }
+]

--- a/tests/test_rewrite.py
+++ b/tests/test_rewrite.py
@@ -1,0 +1,109 @@
+"""Tests for `adguardhome.rewrite`."""
+
+import pytest
+from aioresponses import CallbackResult, aioresponses
+from syrupy.assertion import SnapshotAssertion
+
+from adguardhome import AdGuardHome, RewriteRule
+from adguardhome.exceptions import AdGuardHomeError
+
+from .conftest import FixtureLoader
+
+URL_LIST = "http://example.com:3000/control/rewrite/list"
+URL_ADD = "http://example.com:3000/control/rewrite/add"
+URL_DELETE = "http://example.com:3000/control/rewrite/delete"
+
+
+async def test_list_rules(
+    responses: aioresponses,
+    adguard: AdGuardHome,
+    load_fixture: FixtureLoader,
+) -> None:
+    """Test listing all DNS rewrite rules."""
+    responses.get(URL_LIST, status=200, payload=load_fixture("rewrite_list"))
+
+    result = await adguard.rewrite.list_rules()
+
+    assert len(result) == 2
+    assert result[0] == RewriteRule(
+        domain="*.example.com", answer="192.168.1.2", enabled=True
+    )
+    assert result[1].enabled is False
+
+
+async def test_list_rules_snapshot(
+    responses: aioresponses,
+    adguard: AdGuardHome,
+    load_fixture: FixtureLoader,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test rewrite rule parsing matches snapshot."""
+    responses.get(URL_LIST, status=200, payload=load_fixture("rewrite_list"))
+    assert await adguard.rewrite.list_rules() == snapshot
+
+
+async def test_list_rules_empty(
+    responses: aioresponses,
+    adguard: AdGuardHome,
+) -> None:
+    """Test listing rules returns empty list when none exist."""
+    responses.get(URL_LIST, status=200, payload=[])
+    assert await adguard.rewrite.list_rules() == []
+
+
+async def test_add(
+    responses: aioresponses,
+    adguard: AdGuardHome,
+) -> None:
+    """Test adding a DNS rewrite rule."""
+
+    def callback(_url: str, **kwargs: object) -> CallbackResult:
+        assert kwargs["json"] == {
+            "domain": "*.example.com",
+            "answer": "192.168.1.2",
+        }
+        return CallbackResult(status=200, content_type="text/plain")
+
+    responses.post(URL_ADD, callback=callback)
+    await adguard.rewrite.add("*.example.com", "192.168.1.2")
+
+
+@pytest.mark.parametrize("status", [400, 500])
+async def test_add_error(
+    responses: aioresponses,
+    adguard: AdGuardHome,
+    status: int,
+) -> None:
+    """Test adding a DNS rewrite rule fails on HTTP error."""
+    responses.post(URL_ADD, status=status, body="Error", content_type="text/plain")
+    with pytest.raises(AdGuardHomeError):
+        await adguard.rewrite.add("*.example.com", "192.168.1.2")
+
+
+async def test_delete(
+    responses: aioresponses,
+    adguard: AdGuardHome,
+) -> None:
+    """Test deleting a DNS rewrite rule."""
+
+    def callback(_url: str, **kwargs: object) -> CallbackResult:
+        assert kwargs["json"] == {
+            "domain": "*.example.com",
+            "answer": "192.168.1.2",
+        }
+        return CallbackResult(status=200, content_type="text/plain")
+
+    responses.post(URL_DELETE, callback=callback)
+    await adguard.rewrite.delete("*.example.com", "192.168.1.2")
+
+
+@pytest.mark.parametrize("status", [400, 500])
+async def test_delete_error(
+    responses: aioresponses,
+    adguard: AdGuardHome,
+    status: int,
+) -> None:
+    """Test deleting a DNS rewrite rule fails on HTTP error."""
+    responses.post(URL_DELETE, status=status, body="Error", content_type="text/plain")
+    with pytest.raises(AdGuardHomeError):
+        await adguard.rewrite.delete("*.example.com", "192.168.1.2")


### PR DESCRIPTION
Adds support for adding, deleting and listing DNS rewrite rules via the Adguard Home API