### PR TITLE
Add support for allowlist in filters

### DIFF
--- a/examples/stats.py
+++ b/examples/stats.py
@@ -36,7 +36,7 @@ async def main():
         result = await adguard.stats.replaced_safesearch()
         print("Number of enforced safe searches:", result)
 
-        result = await adguard.filtering.rules_count()
+        result = await adguard.filtering.rules_count(allowlist=False)
         print("Total number of active rules:", result)
 
 


### PR DESCRIPTION
# Proposed Changes

This PR adds support for managing allowlists filters in AdGuard Home.

Additional, this is a bugfix; as currently the filter API calls will fail without the `whitelist` parameter.

Downstream issue: <https://github.com/home-assistant/core/issues/45296>

