### PR TITLE
Fix use of enabling/disabling specific filters

### DIFF
--- a/src/adguardhome/filtering.py
+++ b/src/adguardhome/filtering.py
@@ -162,6 +162,20 @@ class AdGuardHomeFiltering:
         Raises:
             AdGuardHomeError: Failed enabling filter subscription.
         """
+        response = await self._adguard.request("filtering/status")
+        filter_type = "whitelist_filters" if allowlist else "filters"
+
+        # Excluded from coverage:
+        # https://github.com/nedbat/coveragepy/issues/515
+        name = next(  # pragma: no cover
+            (
+                fil["name"]
+                for fil in response[filter_type]
+                if fil["url"].lower() == url.lower()
+            ),
+            "Unknown",
+        )
+
         try:
             await self._adguard.request(
                 "filtering/set_url",
@@ -169,7 +183,7 @@ class AdGuardHomeFiltering:
                 json_data={
                     "url": url,
                     "whitelist": allowlist,
-                    "data": {"enabled": True},
+                    "data": {"enabled": True, "name": name, "url": url},
                 },
             )
         except AdGuardHomeError as exception:
@@ -187,6 +201,20 @@ class AdGuardHomeFiltering:
         Raises:
             AdGuardHomeError: Failed disabling filter subscription.
         """
+        response = await self._adguard.request("filtering/status")
+        filter_type = "whitelist_filters" if allowlist else "filters"
+
+        # Excluded from coverage:
+        # https://github.com/nedbat/coveragepy/issues/515
+        name = next(  # pragma: no cover
+            (
+                fil["name"]
+                for fil in response[filter_type]
+                if fil["url"].lower() == url.lower()
+            ),
+            "Unknown",
+        )
+
         try:
             await self._adguard.request(
                 "filtering/set_url",
@@ -194,7 +222,7 @@ class AdGuardHomeFiltering:
                 json_data={
                     "url": url,
                     "whitelist": allowlist,
-                    "data": {"enabled": False},
+                    "data": {"enabled": False, "name": name, "url": url},
                 },
             )
         except AdGuardHomeError as exception:

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -323,12 +323,36 @@ async def test_enable_url(aresponses):
         assert data == {
             "url": "https://example.com/1.txt",
             "whitelist": False,
-            "data": {"enabled": True},
+            "data": {
+                "enabled": True,
+                "url": "https://example.com/1.txt",
+                "name": "test",
+            },
         }
         return aresponses.Response(status=200, text="OK")
 
     aresponses.add(
+        "example.com:3000",
+        "/control/filtering/status",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text='{"filters": [{"url": "https://EXAMPLE.com/1.txt", "name": "test"}]}',
+        ),
+    )
+    aresponses.add(
         "example.com:3000", "/control/filtering/set_url", "POST", response_handler
+    )
+    aresponses.add(
+        "example.com:3000",
+        "/control/filtering/status",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text='{"filters": [{"url": "https://EXAMPLE.com/1.txt", "name": "test"}]}',
+        ),
     )
     aresponses.add(
         "example.com:3000",
@@ -358,12 +382,36 @@ async def test_disable_url(aresponses):
         assert data == {
             "url": "https://example.com/1.txt",
             "whitelist": False,
-            "data": {"enabled": False},
+            "data": {
+                "enabled": False,
+                "name": "test",
+                "url": "https://example.com/1.txt",
+            },
         }
         return aresponses.Response(status=200)
 
     aresponses.add(
+        "example.com:3000",
+        "/control/filtering/status",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text='{"filters": [{"url": "https://EXAMPLE.com/1.txt", "name": "test"}]}',
+        ),
+    )
+    aresponses.add(
         "example.com:3000", "/control/filtering/set_url", "POST", response_handler
+    )
+    aresponses.add(
+        "example.com:3000",
+        "/control/filtering/status",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text='{"filters": [{"url": "https://example.com/1.txt", "name": "test"}]}',
+        ),
     )
     aresponses.add(
         "example.com:3000",


### PR DESCRIPTION
# Proposed Changes

With the recent changes made to the API of AdGuard Home, they made some weird changes that require the name of the specific filters to enable/disable a filter.

The API is clearly created with simply their own UI in mind, because from an actual API perspective, this doesn't make sense.

Anyways, this works around it.

Downstream issue: <https://github.com/home-assistant/core/issues/45296>
