### PR TITLE
Fix type hint for client constructor arguments

### DIFF
--- a/src/adguardhome/adguardhome.py
+++ b/src/adguardhome/adguardhome.py
@@ -29,13 +29,13 @@ class AdGuardHome:
         host: str,
         *,
         base_path: str = "/control",
-        password: str = None,
+        password: str | None = None,
         port: int = 3000,
         request_timeout: int = 10,
         session: aiohttp.client.ClientSession | None = None,
         tls: bool = False,
-        user_agent: str = None,
-        username: str = None,
+        user_agent: str | None = None,
+        username: str | None = None,
         verify_ssl: bool = True,
     ) -> None:
         """Initialize connection with AdGuard Home.


### PR DESCRIPTION
# Proposed Changes

Type hint and their allowed values didn't match in the constructor signature. This PR fixes that.
