### PR TITLE
Fix async_timeout deprecation warning.

### DIFF
--- a/src/adguardhome/adguardhome.py
+++ b/src/adguardhome/adguardhome.py
@@ -132,7 +132,7 @@ class AdGuardHome:
             self._close_session = True
 
         try:
-            with async_timeout.timeout(self.request_timeout):
+            async with async_timeout.timeout(self.request_timeout):
                 response = await self._session.request(
                     method,
                     url,


### PR DESCRIPTION
# Proposed Changes

A very simple fix for the deprecation warning from `async_timeout` when testing home assistant's `adguard` integration:

```
tests/components/adguard/test_config_flow.py: 32 warnings
 /homeassistant/lib/python3.9/site-packages/adguardhome/adguardhome.py:135: DeprecationWarning: with timeout() is deprecated, use async with timeout() instead
    with async_timeout.timeout(self.request_timeout):
```

## Related Issues


[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
