### PR TITLE
Fix content-type handing for JSON requests

### DIFF
--- a/src/adguardhome/adguardhome.py
+++ b/src/adguardhome/adguardhome.py
@@ -131,10 +131,11 @@ class AdGuardHome:
             self._session = aiohttp.ClientSession()
             self._close_session = True
 
+        skip_auto_headers = None
+        if data is None and json_data is None:
+            skip_auto_headers = {"Content-Type"}
+
         try:
-            skip_auto_headers = None
-            if data is None:
-                skip_auto_headers = {"Content-Type"}
             async with async_timeout.timeout(self.request_timeout):
                 response = await self._session.request(
                     method,


### PR DESCRIPTION
# Proposed Changes

Fixes a regression introduced in #677. Content headers for JSON data should be handled.
This fixes the controls of, e.g., protection mode.
