### PR TITLE
feat: Add cache_clear method to AdGuardHome class

### DIFF
--- a/src/adguardhome/adguardhome.py
+++ b/src/adguardhome/adguardhome.py
@@ -228,6 +228,20 @@ class AdGuardHome:
             msg = "Failed disabling AdGuard Home protection"
             raise AdGuardHomeError(msg) from exception
 
+    async def cache_clear(self) -> None:
+        """Clear the cache of the AdGuard Home instance.
+
+        Raises
+        ------
+            AdGuardHomeError: Failed clearing the cache of the AdGuard Home instance.
+
+        """
+        try:
+            await self.request("cache_clear", method="POST")
+        except AdGuardHomeError as exception:
+            msg = "Failed clearing the cache of the AdGuard Home instance"
+            raise AdGuardHomeError(msg) from exception
+
     async def version(self) -> str:
         """Return the current version of the AdGuard Home instance.
 

--- a/tests/test_adguardhome.py
+++ b/tests/test_adguardhome.py
@@ -311,3 +311,25 @@ async def test_verion(aresponses: ResponsesMockServer) -> None:
         adguard = AdGuardHome("example.com", session=session)
         version = await adguard.version()
         assert version == "1.1"
+
+
+async def test_clear_cache(aresponses: ResponsesMockServer) -> None:
+    """Test clearing the cache of AdGuard Home instance."""
+    aresponses.add(
+        "example.com:3000",
+        "/control/cache_clear",
+        "POST",
+        aresponses.Response(status=200),
+    )
+    aresponses.add(
+        "example.com:3000",
+        "/control/cache_clear",
+        "POST",
+        aresponses.Response(status=404),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        adguard = AdGuardHome("example.com", session=session)
+        await adguard.cache_clear()
+        with pytest.raises(AdGuardHomeError):
+            await adguard.cache_clear()


### PR DESCRIPTION

# Proposed Changes

> This commit adds a new method `cache_clear` to the `AdGuardHome` class in the `adguardhome.py` file. The `cache_clear` method allows clearing the cache of the AdGuard Home instance. It sends a POST request to the `/control/cache_clear` endpoint.

This change was made to provide a convenient way for users to clear the cache of the AdGuard Home instance.


## Related Issues

> #1095 
