### PR TITLE
Add ability to pause protection temporarily

### DIFF
--- a/src/adguardhome/adguardhome.py
+++ b/src/adguardhome/adguardhome.py
@@ -219,6 +219,28 @@ class AdGuardHome:
             msg = "Failed disabling AdGuard Home protection"
             raise AdGuardHomeError(msg) from exception
 
+    async def pause_protection(self, duration: int) -> None:
+        """Disable AdGuard Home protection for a defined amount of time.
+
+        Args:
+        ----
+            duration: Set the duration (in milliseconds) to pause protection.
+
+        Raises:
+        ------
+            AdGuardHomeError: Failed pausing the AdGuard Home protection.
+
+        """
+        try:
+            await self.request(
+                "protection",
+                method="POST",
+                json_data={"enabled": False, "duration": duration},
+            )
+        except AdGuardHomeError as exception:
+            msg = "Failed pausing AdGuard Home protection"
+            raise AdGuardHomeError(msg) from exception
+
     async def version(self) -> str:
         """Return the current version of the AdGuard Home instance.
 


### PR DESCRIPTION
# Proposed Changes

> AdGuard has a GUI feature and REST endpoint that can be used to temporarily disable/pause protection for a specified amount of time. This change would enable the usage of that API. 

# Notes

This is just a quick crack at implementation — happy to hear any feedback on this and welcome any modifications. 

## Tests

I put together a basic test on this but wasn't quite happy with how it feels a bit half-tested. If there are any suggestions on how to better write that test, I am all ears! 
