### PR TITLE
Use python:1-3.11 dev-conatiner image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,7 +51,7 @@
       "installTools": false
     }
   },
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.11",
   "name": "Asynchronous Python client for the AdGuard Home API",
   "updateContentCommand": ". ${NVM_DIR}/nvm.sh && nvm install && nvm use && npm install && poetry install && poetry run pre-commit install"
 }


### PR DESCRIPTION
# Proposed Changes

Make use of the pre-build python 3.11 dev-container image, since the `base:ubuntu` seems to be delivered with only python 3.10

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
