### PR TITLE
Add support for auto-upgrade procedure

### DIFF
--- a/src/adguardhome/adguardhome.py
+++ b/src/adguardhome/adguardhome.py
@@ -17,6 +17,7 @@ from .querylog import AdGuardHomeQueryLog
 from .safebrowsing import AdGuardHomeSafeBrowsing
 from .safesearch import AdGuardHomeSafeSearch
 from .stats import AdGuardHomeStats
+from .update import AdGuardHomeUpdate
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -79,6 +80,7 @@ class AdGuardHome:
         self.safebrowsing = AdGuardHomeSafeBrowsing(self)
         self.safesearch = AdGuardHomeSafeSearch(self)
         self.stats = AdGuardHomeStats(self)
+        self.update = AdGuardHomeUpdate(self)
 
     # pylint: disable-next=too-many-arguments, too-many-locals, too-many-positional-arguments
     async def request(

--- a/src/adguardhome/update.py
+++ b/src/adguardhome/update.py
@@ -1,0 +1,54 @@
+"""Asynchronous Python client for the AdGuard Home API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .exceptions import AdGuardHomeError
+
+if TYPE_CHECKING:
+    from . import AdGuardHome
+
+
+@dataclass
+class AdGuardHomeAvailableUpdate:
+    """Latests available AdGuard Home update."""
+
+    new_version: str
+    announcement: str
+    announcement_url: str
+    can_autoupdate: bool
+    disabled: bool
+
+
+@dataclass
+class AdGuardHomeUpdate:
+    """Controls AdGuard Home version update."""
+
+    adguard: AdGuardHome
+
+    async def update_available(self) -> AdGuardHomeAvailableUpdate:
+        """Return AdGuard Home latest available update.
+
+        Returns
+        -------
+            An AdGuardHomeAvailableUpdate object with all data about the latest update.
+
+        """
+        response = await self.adguard.request("version.json", method="POST")
+        return AdGuardHomeAvailableUpdate(**response)
+
+    async def begin_update(self) -> None:
+        """Begin AdGuard Home auto-upgrade procedure.
+
+        Raises
+        ------
+            AdGuardHomeError: If beginning the auto-upgrade failed.
+
+        """
+        try:
+            await self.adguard.request("update", method="POST")
+        except AdGuardHomeError as exception:
+            msg = "Begin AdGuard Home update failed"
+            raise AdGuardHomeError(msg) from exception

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,64 @@
+"""Tests for `adguardhome.update`."""
+
+import aiohttp
+import pytest
+from aresponses import ResponsesMockServer
+
+from adguardhome import AdGuardHome
+from adguardhome.exceptions import AdGuardHomeError
+
+
+async def test_update_available(aresponses: ResponsesMockServer) -> None:
+    """Test request of current AdGuard Home latest available update."""
+    aresponses.add(
+        "example.com:3000",
+        "/control/version.json",
+        "POST",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text=(
+                '{"new_version":"v0.107.59",'
+                '"announcement":"AdGuard Home v0.107.59 is now available!",'
+                '"announcement_url":"https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.107.59",'
+                '"can_autoupdate":true,"disabled":false}'
+            ),
+        ),
+    )
+    async with aiohttp.ClientSession() as session:
+        adguard = AdGuardHome("example.com", session=session)
+        available_update = await adguard.update.update_available()
+        assert available_update
+        assert (
+            available_update.announcement == "AdGuard Home v0.107.59 is now available!"
+        )
+        assert (
+            available_update.announcement_url
+            == "https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.107.59"
+        )
+        assert available_update.can_autoupdate
+        assert available_update.disabled is False
+        assert available_update.new_version == "v0.107.59"
+
+
+async def test_begin_update(aresponses: ResponsesMockServer) -> None:
+    """Test beginning AdGuard Home automatic upgrade."""
+    # Handle to run asserts on request in
+    aresponses.add(
+        "example.com:3000",
+        "/control/update",
+        "POST",
+        aresponses.Response(status=200, text="OK"),
+    )
+    aresponses.add(
+        "example.com:3000",
+        "/control/update",
+        "POST",
+        aresponses.Response(status=400, text="NOT OK"),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        adguard = AdGuardHome("example.com", session=session)
+        await adguard.update.begin_update()
+        with pytest.raises(AdGuardHomeError):
+            await adguard.update.begin_update()


### PR DESCRIPTION
# Proposed Changes

This adds the support for the auto-upgrade procedure, so we can check for an available update and trigger the installation of it. It is planned to use this for adding an `update` entity to the [AdGuard Home](https://www.home-assistant.io/integrations/adguard) integration in HA

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
