### PR TITLE
feat: Add a method to check if a filter list is enabled by url

### DIFF
--- a/src/adguardhome/filtering.py
+++ b/src/adguardhome/filtering.py
@@ -247,6 +247,21 @@ class AdGuardHomeFiltering:
             msg = "Failed disabling URL on AdGuard Home filter"
             raise AdGuardHomeError(msg) from exception
 
+    async def url_enabled(self, *, allowlist: bool, url: str) -> bool:
+        """Check if a filter subscription is enabled in AdGuard Home.
+
+        Args:
+        ----
+            allowlist: True to check an allowlist, False for a blocklists.
+            url: Filter subscription URL to check on AdGuard Home.
+
+        """
+        response = await self.adguard.request("filtering/status")
+        filter_type = "whitelist_filters" if allowlist else "filters"
+        filters = response.get(filter_type) or []
+
+        return any(fil["url"].lower() == url.lower() for fil in filters)
+
     async def refresh(self, *, allowlist: bool, force: bool = False) -> None:
         """Reload filtering subscriptions from URLs specified in AdGuard Home.
 

--- a/src/adguardhome/filtering.py
+++ b/src/adguardhome/filtering.py
@@ -260,7 +260,10 @@ class AdGuardHomeFiltering:
         filter_type = "whitelist_filters" if allowlist else "filters"
         filters = response.get(filter_type) or []
 
-        return any(fil["url"].lower() == url.lower() for fil in filters)
+        return next(
+            (fil["enabled"] for fil in filters if fil["url"].lower() == url.lower()),
+            False,
+        )
 
     async def refresh(self, *, allowlist: bool, force: bool = False) -> None:
         """Reload filtering subscriptions from URLs specified in AdGuard Home.

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -428,6 +428,55 @@ async def test_disable_url(aresponses: ResponsesMockServer) -> None:
             )
 
 
+async def test_url_enabled(aresponses: ResponsesMockServer) -> None:
+    """Test checking if filter subscription is enabled in AdGuard Home filtering."""
+    aresponses.add(
+        "example.com:3000",
+        "/control/filtering/status",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text='{"filters": [{"url": "https://EXAMPLE.com/1.txt", "name": "test"}]}',
+        ),
+    )
+    aresponses.add(
+        "example.com:3000",
+        "/control/filtering/status",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text='{"whitelist_filters": [{"url": "http://ex.co/1.txt", "name": "ex"}]}',
+        ),
+    )
+    aresponses.add(
+        "example.com:3000",
+        "/control/filtering/status",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text='{"filters": [{"url": "https://EXAMPLE.com/1.txt", "name": "test"}]}',
+        ),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        adguard = AdGuardHome("example.com", session=session)
+        enabled = await adguard.filtering.url_enabled(
+            allowlist=False, url="https://example.com/1.txt"
+        )
+        assert enabled
+        enabled = await adguard.filtering.url_enabled(
+            allowlist=True, url="http://EX.co/1.txt"
+        )
+        assert enabled
+        enabled = await adguard.filtering.url_enabled(
+            allowlist=True, url="https://example.com/1.txt"
+        )
+        assert not enabled
+
+
 async def test_refresh(aresponses: ResponsesMockServer) -> None:
     """Test enabling filter subscription in AdGuard Home filtering."""
 


### PR DESCRIPTION
# Proposed Changes

#### Adds the ability to check if a filter list is enabled
- It would support the ability to create custom sensors for specific lists in Home Assistant

## Related Issues

- Resolves #1556
