### PR TITLE
Add disable protection for a specific duration

### DIFF
--- a/src/adguardhome/adguardhome.py
+++ b/src/adguardhome/adguardhome.py
@@ -198,27 +198,38 @@ class AdGuardHome:
         """
         try:
             await self.request(
-                "dns_config",
+                "protection",
                 method="POST",
-                json_data={"protection_enabled": True},
+                json_data={"enabled": True},
             )
         except AdGuardHomeError as exception:
             msg = "Failed enabling AdGuard Home protection"
             raise AdGuardHomeError(msg) from exception
 
-    async def disable_protection(self) -> None:
+    async def disable_protection(
+        self, pause_duration_milliseconds: int | None = None
+    ) -> None:
         """Disable AdGuard Home protection.
 
-        Raises
+        Args:
+        ----
+            pause_duration_milliseconds : int | None, optional
+                Specifies the duration in milliseconds for which protection should be
+                disabled.
+
+        Raises:
         ------
             AdGuardHomeError: Failed disabling the AdGuard Home protection.
 
         """
         try:
+            data: dict[str, Any] = {"enabled": False}
+            if pause_duration_milliseconds:
+                data["duration"] = pause_duration_milliseconds
             await self.request(
-                "dns_config",
+                "protection",
                 method="POST",
-                json_data={"protection_enabled": False},
+                json_data=data,
             )
         except AdGuardHomeError as exception:
             msg = "Failed disabling AdGuard Home protection"

--- a/tests/test_adguardhome.py
+++ b/tests/test_adguardhome.py
@@ -219,13 +219,13 @@ async def test_enable_protection(aresponses: ResponsesMockServer) -> None:
     """Test enabling AdGuard Home protection."""
     aresponses.add(
         "example.com:3000",
-        "/control/dns_config",
+        "/control/protection",
         "POST",
         aresponses.Response(status=200),
     )
     aresponses.add(
         "example.com:3000",
-        "/control/dns_config",
+        "/control/protection",
         "POST",
         aresponses.Response(status=400),
     )
@@ -241,13 +241,13 @@ async def test_disable_protection(aresponses: ResponsesMockServer) -> None:
     """Test disabling AdGuard Home protection."""
     aresponses.add(
         "example.com:3000",
-        "/control/dns_config",
+        "/control/protection",
         "POST",
         aresponses.Response(status=200),
     )
     aresponses.add(
         "example.com:3000",
-        "/control/dns_config",
+        "/control/protection",
         "POST",
         aresponses.Response(status=500),
     )
@@ -259,7 +259,30 @@ async def test_disable_protection(aresponses: ResponsesMockServer) -> None:
             await adguard.disable_protection()
 
 
-async def test_verion(aresponses: ResponsesMockServer) -> None:
+async def test_disable_protection_with_duration(
+    aresponses: ResponsesMockServer,
+) -> None:
+    """Test disabling AdGuard Home protection with a pause duration."""
+
+    async def handler(request: aiohttp.web.Request) -> Response:
+        # Validate JSON body contains the expected duration
+        payload = await request.json()
+        assert payload == {"enabled": False, "duration": 15000}
+        return aresponses.Response(status=200)
+
+    aresponses.add(
+        "example.com:3000",
+        "/control/protection",
+        "POST",
+        handler,
+    )
+
+    async with aiohttp.ClientSession() as session:
+        adguard = AdGuardHome("example.com", session=session)
+        await adguard.disable_protection(pause_duration_milliseconds=15000)
+
+
+async def test_version(aresponses: ResponsesMockServer) -> None:
     """Test requesting AdGuard Home instance version."""
     aresponses.add(
         "example.com:3000",


### PR DESCRIPTION
# Proposed Changes

Since AGH [v0.107.28](https://github.com/AdguardTeam/AdGuardHome/compare/v0.107.27...v0.107.28), AGH allow to disable protection for a specific duration (see https://github.com/AdguardTeam/AdGuardHome/issues/1333).
This option is not present in `disable_protection`, hence, cannot be used in Home Assistant, using a `service`.
This PR introduces having an optional `pause_duration_miliseconds` parameter.

## Related Issues

#1030