### PR TITLE
✨ Add client management API

### DIFF
--- a/src/adguardhome/__init__.py
+++ b/src/adguardhome/__init__.py
@@ -1,6 +1,13 @@
 """Asynchronous Python client for the AdGuard Home API."""
 
 from .adguardhome import AdGuardHome
+from .client import AutoClient, Client
 from .exceptions import AdGuardHomeConnectionError, AdGuardHomeError
 
-__all__ = ["AdGuardHome", "AdGuardHomeConnectionError", "AdGuardHomeError"]
+__all__ = [
+    "AdGuardHome",
+    "AdGuardHomeConnectionError",
+    "AdGuardHomeError",
+    "AutoClient",
+    "Client",
+]

--- a/src/adguardhome/adguardhome.py
+++ b/src/adguardhome/adguardhome.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Self
 import aiohttp
 from yarl import URL
 
+from .client import AdGuardHomeClients
 from .exceptions import AdGuardHomeConnectionError, AdGuardHomeError
 from .filtering import AdGuardHomeFiltering
 from .parental import AdGuardHomeParental
@@ -74,6 +75,7 @@ class AdGuardHome:
         if self.base_path[-1] != "/":
             self.base_path += "/"
 
+        self.clients = AdGuardHomeClients(self)
         self.filtering = AdGuardHomeFiltering(self)
         self.parental = AdGuardHomeParental(self)
         self.querylog = AdGuardHomeQueryLog(self)

--- a/src/adguardhome/client.py
+++ b/src/adguardhome/client.py
@@ -1,0 +1,93 @@
+"""Asynchronous Python client for the AdGuard Home API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from . import AdGuardHome
+
+
+@dataclass
+class AutoClient:
+    """Automatically discovered AdGuard Home client."""
+
+    ip_address: str
+    name: str
+    source: str
+    whois_info: dict[str, str] | None = None
+
+
+@dataclass
+class Client:
+    """Administratively managed AdGuard Home client."""
+
+    name: str
+    ids: list[str]
+    use_global_settings: bool = True
+    filtering_enabled: bool = False
+    parental_enabled: bool = False
+    safebrowsing_enabled: bool = False
+    safesearch_enabled: bool = False
+    use_global_blocked_services: bool = True
+    blocked_services: list[str] | None = None
+    upstreams: list[str] | None = None
+    tags: list[str] | None = None
+    ignore_querylog: bool = False
+    ignore_statistics: bool = False
+    upstreams_cache_enabled: bool = False
+    upstreams_cache_size: int = 0
+
+
+@dataclass
+class AdGuardHomeClients:
+    """Controls AdGuard Home client management."""
+
+    adguard: AdGuardHome
+
+    async def get_auto_clients(self) -> list[AutoClient]:
+        """Return all automatically discovered clients.
+
+        Returns
+        -------
+            A list of automatically discovered clients on the
+            AdGuard Home instance.
+
+        """
+        response = await self.adguard.request("clients")
+        return [
+            AutoClient(
+                ip_address=entry["ip"],
+                name=entry["name"],
+                source=entry["source"],
+                whois_info=entry.get("whois_info"),
+            )
+            for entry in response.get("auto_clients", [])
+        ]
+
+    async def get_clients(self) -> list[Client]:
+        """Return all administratively configured clients.
+
+        Returns
+        -------
+            A list of configured clients on the AdGuard Home instance.
+
+        """
+        response = await self.adguard.request("clients")
+        known = {f.name for f in fields(Client)}
+        return [
+            Client(**{k: v for k, v in entry.items() if k in known})
+            for entry in response.get("clients", [])
+        ]
+
+    async def get_supported_tags(self) -> list[str]:
+        """Return the list of supported client tags.
+
+        Returns
+        -------
+            The supported tags for clients on the AdGuard Home instance.
+
+        """
+        response = await self.adguard.request("clients")
+        return response.get("supported_tags", [])

--- a/tests/__snapshots__/test_client.ambr
+++ b/tests/__snapshots__/test_client.ambr
@@ -1,0 +1,12 @@
+# serializer version: 1
+# name: test_get_auto_clients_snapshot
+  list([
+    AutoClient(ip_address='192.168.1.10', name='phone', source='rdns', whois_info=None),
+    AutoClient(ip_address='192.168.1.20', name='laptop', source='arp', whois_info={'orgname': 'Local Network'}),
+  ])
+# ---
+# name: test_get_clients_snapshot
+  list([
+    Client(name='Kids devices', ids=['192.168.1.30', '192.168.1.31'], use_global_settings=False, filtering_enabled=True, parental_enabled=True, safebrowsing_enabled=True, safesearch_enabled=True, use_global_blocked_services=False, blocked_services=['youtube'], upstreams=[], tags=['device_tablet'], ignore_querylog=False, ignore_statistics=False, upstreams_cache_enabled=False, upstreams_cache_size=0),
+  ])
+# ---

--- a/tests/fixtures/clients.json
+++ b/tests/fixtures/clients.json
@@ -1,0 +1,48 @@
+{
+  "auto_clients": [
+    {
+      "ip": "192.168.1.10",
+      "name": "phone",
+      "source": "rdns"
+    },
+    {
+      "ip": "192.168.1.20",
+      "name": "laptop",
+      "source": "arp",
+      "whois_info": {
+        "orgname": "Local Network"
+      }
+    }
+  ],
+  "clients": [
+    {
+      "name": "Kids devices",
+      "ids": ["192.168.1.30", "192.168.1.31"],
+      "use_global_settings": false,
+      "filtering_enabled": true,
+      "parental_enabled": true,
+      "safebrowsing_enabled": true,
+      "safesearch_enabled": true,
+      "use_global_blocked_services": false,
+      "blocked_services": ["youtube"],
+      "upstreams": [],
+      "tags": ["device_tablet"],
+      "ignore_querylog": false,
+      "ignore_statistics": false,
+      "upstreams_cache_enabled": false,
+      "upstreams_cache_size": 0
+    }
+  ],
+  "supported_tags": [
+    "device_laptop",
+    "device_phone",
+    "device_tablet",
+    "os_android",
+    "os_ios",
+    "os_linux",
+    "os_macos",
+    "os_windows",
+    "user_admin",
+    "user_child"
+  ]
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,134 @@
+"""Tests for `adguardhome.client`."""
+
+import pytest
+from aioresponses import aioresponses
+from syrupy.assertion import SnapshotAssertion
+
+from adguardhome import AdGuardHome, AutoClient
+
+from .conftest import FixtureLoader
+
+URL_CLIENTS = "http://example.com:3000/control/clients"
+
+
+async def test_get_auto_clients(
+    responses: aioresponses,
+    adguard: AdGuardHome,
+    load_fixture: FixtureLoader,
+) -> None:
+    """Test listing automatically discovered clients."""
+    responses.get(URL_CLIENTS, status=200, payload=load_fixture("clients"))
+
+    result = await adguard.clients.get_auto_clients()
+
+    assert len(result) == 2
+    assert result[0] == AutoClient(
+        ip_address="192.168.1.10",
+        name="phone",
+        source="rdns",
+    )
+    assert result[1].whois_info == {"orgname": "Local Network"}
+
+
+async def test_get_auto_clients_snapshot(
+    responses: aioresponses,
+    adguard: AdGuardHome,
+    load_fixture: FixtureLoader,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test auto_clients parsing matches snapshot."""
+    responses.get(URL_CLIENTS, status=200, payload=load_fixture("clients"))
+    assert await adguard.clients.get_auto_clients() == snapshot
+
+
+async def test_get_clients(
+    responses: aioresponses,
+    adguard: AdGuardHome,
+    load_fixture: FixtureLoader,
+) -> None:
+    """Test listing configured clients."""
+    responses.get(URL_CLIENTS, status=200, payload=load_fixture("clients"))
+
+    result = await adguard.clients.get_clients()
+
+    assert len(result) == 1
+    client = result[0]
+    assert client.name == "Kids devices"
+    assert client.ids == ["192.168.1.30", "192.168.1.31"]
+    assert client.filtering_enabled is True
+    assert client.parental_enabled is True
+    assert client.use_global_settings is False
+    assert client.blocked_services == ["youtube"]
+    assert client.tags == ["device_tablet"]
+
+
+async def test_get_clients_snapshot(
+    responses: aioresponses,
+    adguard: AdGuardHome,
+    load_fixture: FixtureLoader,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test clients parsing matches snapshot."""
+    responses.get(URL_CLIENTS, status=200, payload=load_fixture("clients"))
+    assert await adguard.clients.get_clients() == snapshot
+
+
+async def test_get_clients_ignores_unknown_fields(
+    responses: aioresponses,
+    adguard: AdGuardHome,
+) -> None:
+    """Test that unknown fields from the API are silently ignored."""
+    responses.get(
+        URL_CLIENTS,
+        status=200,
+        payload={
+            "auto_clients": [],
+            "clients": [
+                {
+                    "name": "test",
+                    "ids": ["192.168.1.1"],
+                    "use_global_settings": True,
+                    "some_future_field": "should be ignored",
+                    "another_unknown": 42,
+                },
+            ],
+            "supported_tags": [],
+        },
+    )
+
+    result = await adguard.clients.get_clients()
+    assert len(result) == 1
+    assert result[0].name == "test"
+
+
+async def test_get_supported_tags(
+    responses: aioresponses,
+    adguard: AdGuardHome,
+    load_fixture: FixtureLoader,
+) -> None:
+    """Test listing supported client tags."""
+    responses.get(URL_CLIENTS, status=200, payload=load_fixture("clients"))
+
+    result = await adguard.clients.get_supported_tags()
+
+    assert len(result) == 10
+    assert "device_tablet" in result
+    assert "user_child" in result
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["get_auto_clients", "get_clients", "get_supported_tags"],
+)
+async def test_empty_response(
+    responses: aioresponses,
+    adguard: AdGuardHome,
+    method: str,
+) -> None:
+    """Test all methods return empty lists when no data is present."""
+    responses.get(
+        URL_CLIENTS,
+        status=200,
+        payload={"auto_clients": [], "clients": [], "supported_tags": []},
+    )
+    assert await getattr(adguard.clients, method)() == []


### PR DESCRIPTION
## Summary

- Add `adguard.clients` namespace with read-only access to the AdGuard Home `/clients` API
- `get_auto_clients()` — list automatically discovered clients
- `get_clients()` — list administratively configured clients
- `get_supported_tags()` — list supported client tags
- New `AutoClient` and `Client` dataclasses exported from `adguardhome`
- Unknown API fields are silently ignored (future-proof against schema additions)

Based on the work in #694 by @offbyone, rewritten to match current project conventions (aioresponses, JSON fixtures, snapshot tests, parametrized tests).

Supersedes #694.

## Test plan

- [x] Auto-client parsing with and without whois_info
- [x] Configured client parsing with all fields
- [x] Unknown fields from API are silently ignored
- [x] Supported tags listing
- [x] Empty responses return empty lists (parametrized across all 3 methods)
- [x] Snapshot tests lock parsed dataclass shapes
- [x] 121 tests, 99.76% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)